### PR TITLE
wl-42426: [WL Explorer] Add Book Now tabs to SDK models EventListModel and EventView/ElementModel

### DIFF
--- a/WellnessLiving/Wl/Event/Book/EventView/ElementModel.php
+++ b/WellnessLiving/Wl/Event/Book/EventView/ElementModel.php
@@ -69,6 +69,16 @@ class ElementModel extends WlModelAbstract
   public $a_class_logo = null;
 
   /**
+   * The list of tab keys for the class.
+   *
+   * `null` if not loaded yet.
+   *
+   * @get result
+   * @var array|null
+   */
+  public $a_class_tab = null;
+
+  /**
    * Displays information for a bulk of events.
    *
    * Received only if {@link ElementModel::$s_event} has been specified. In this case, other fields aren't receivers.


### PR DESCRIPTION
Added field for the book now tab keys to the elementmodel. EventListmodel does not need changes in SDK since data will be present in the existing array.